### PR TITLE
Adding a hint to remind users that ADB is automatically running at bo…

### DIFF
--- a/app/src/main/java/com/yaerin/wadb/BootCompletedReceiver.java
+++ b/app/src/main/java/com/yaerin/wadb/BootCompletedReceiver.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.preference.PreferenceManager;
+import android.widget.Toast;
 
 import static com.yaerin.wadb.Utilities.PREF_AUTO_RUN;
 import static com.yaerin.wadb.Utilities.setWadbState;
@@ -14,7 +15,8 @@ public class BootCompletedReceiver extends BroadcastReceiver {
     public void onReceive(Context context, Intent intent) {
         SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(context);
         if (Intent.ACTION_BOOT_COMPLETED.equals(intent.getAction()) && pref.getBoolean(PREF_AUTO_RUN, false)) {
-            setWadbState(true);
+            if (setWadbState(true))
+                Toast.makeText(context, context.getString(R.string.adb_running), Toast.LENGTH_LONG).show();
         }
     }
 }

--- a/app/src/main/java/com/yaerin/wadb/MainActivity.java
+++ b/app/src/main/java/com/yaerin/wadb/MainActivity.java
@@ -45,10 +45,9 @@ public class MainActivity extends Activity {
                 setChecked(checked);
             }
         });
-        ((Switch) findViewById(R.id.autoRun)).setOnCheckedChangeListener((v, checked) -> {
-            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(MainActivity.this);
-            pref.edit().putBoolean(PREF_AUTO_RUN, checked).apply();
-        });
+        SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(MainActivity.this);
+        ((Switch) findViewById(R.id.autoRun)).setOnCheckedChangeListener((v, checked) -> pref.edit().putBoolean(PREF_AUTO_RUN, checked).apply());
+        ((Switch) findViewById(R.id.autoRun)).setChecked(pref.getBoolean(PREF_AUTO_RUN, false));
         mReceiver = new StateReceiver();
         registerReceiver(mReceiver, new IntentFilter(INTENT_ACTION_ADB_STATE));
     }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -11,4 +11,5 @@
     <string name="ok">确定</string>
     <string name="donate">捐赠</string>
     <string name="auto_run">开机自启</string>
+    <string name="adb_running">网络ADB服务正在运行…</string>
 </resources>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -11,4 +11,5 @@
     <string name="ok">確定</string>
     <string name="donate">捐贈</string>
     <string name="auto_run">開機自啟</string>
+    <string name="adb_running">網絡ADB服務正在運行…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,4 +11,5 @@
     <string name="ok">OK</string>
     <string name="donate">Donate</string>
     <string name="auto_run">Auto run</string>
+    <string name="adb_running">ADB network service is running…</string>
 </resources>


### PR DESCRIPTION
…ot time can be a security risk.

Bug Fix:Switch checked state changes with autorun config.

开机自启的ADB网络服务有可能会成为一个安全风险，因此有必要给用户作出提示。本pr仅仅在服务开机启动时显示一条toast。
修复开机自启开关没有按照配置调整状态的bug。